### PR TITLE
feat: update documentation to use docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,30 @@ This can be found in the Github Repository, as well as inside the Docker image.
 
 ## Using the Docker images
 
-There are two docker images, one for running a Pod (`ghcr.io/bitfount/pod:stable`),
-and another for running a modelling task (`ghcr.io/bitfount/modeller:stable`).
+Our Pod (Process Of Data) docker image is available via Github Container Registry: `ghcr.io/bitfount/pod:stable`
+
+If you have any problems with any of the steps in this README then feel free to reach out to us.
 
 ## Providing the Config & Data
-Both of the images require a `config.yaml` file to be provided to them,
-by default they will try to load it from `/mount/config/config.yaml` inside the docker container.
-You can provide this file easily by mounting/binding a volume to the container,
-how you do this may vary depending on your platform/environment (Docker/docker-compose/ECS),
-if you have any problems doing this then feel free to reach out to us.
+The image requires a valid `config.yaml` file to be provided to them,
+by default they will try to load the file from `/mount/config/config.yaml` inside the docker container.
 
-Here's how it can be done with the `docker run` command:
-```
-docker run -d -v /path/to/config/directory:/mount/config ghcr.io/bitfount/pod:stable
-```
+You can use the provided docker compose file by storing your config at `~/.bitfount_dev/docker/config.yaml` and running `docker compose up pod`.
 
-Alternative you could copy a config file into a stopped container using [docker cp](https://docs.docker.com/engine/reference/commandline/cp/).
+Alternatively you could copy a config file into a stopped container using [docker cp](https://docs.docker.com/engine/reference/commandline/cp/).
 
-If you're using a CSV data source then you'll also need to mount your data to the container,
+**If you're using a CSV data source** then you'll also need to mount your data to the container,
 this will need to be mounted at the path specified in your config, for simplicity it's easiest
-put your config and your CSV in the same directory and then mount it to the container.
-
-## Providing storage for Authentication Tokens
-To avoid having to log in repeatedly whenever a Pod or Modeller container is restarted, you can bind a volume on your host machine to the container which will store your access tokens.
-
-The location inside the container to mount to is: `/root/.bitfount/`, so your `docker run` command might look like this:
-```
-docker run -d -v /path/to/config/directory:/mount/config -v /path/to/directory/for/auth/tokens:/root/.bitfount ghcr.io/bitfount/pod:stable
-```
+put your config and your CSV in the same directory and then mount it to the container. 
+For example you could provide it at `~/.bitfount_dev/docker/data.csv`.
 
 ## Starting the Pod
 Once your container is running you will need to check the logs and complete the login step,
 allowing your container to authenticate with Bitfount.
 The process is the same as when running locally (e.g. the tutorials),
 except that we can't open the login page automatically for you.
+
+You can also use API keys in the `config.yaml` which will enable the pod to run indefinitely.
 
 ## Running with GPU(s) (NVIDIA CUDA)
 To run the pod with a GPU it's recommended to use a Deep Learning Image when provisioning your host machine.
@@ -70,14 +60,9 @@ Docker and the nvidia container toolkit are easy to install if they are missing,
 Here's an example of a suitable image provided by AWS:
 ![](assets/images/AWS_Deep_Learning_Image.png)
 
-Once you've provisioned your machine you just need to pull down the pod image:
-```bash
-docker pull ghcr.io/bitfount/pod:stable
+Once you've provisioned your machine you can run the `gpu` pod with the entrypoint set to `nvidia-smi` to ensure that it's available inside the container:
 ```
-
-Then test that `nvidia-smi` is available _inside_ the container:
-```bash
-docker run -it --gpus all --entrypoint nvidia-smi ghcr.io/bitfount/pod:stable
+docker compose up gpu-checker
 ```
 
 The result should look something like this:
@@ -85,15 +70,12 @@ The result should look something like this:
 
 If that's all working then you can run the pod with GPU access:
 ```bash
-docker run -d --gpus all -v /path/to/config/directory:/mount/config -v /path/to/directory/for/auth/tokens:/root/.bitfount ghcr.io/bitfount/pod:stable
+docker compose up gpu-pod
 ```
-Not forgetting any arguments that you need for mounting volumes etc.
-
-These GPU run arguments are all [documented by Docker](https://docs.docker.com/config/containers/resource_constraints/#access-an-nvidia-gpu), and support is also available in docker-compose.
 
 
 ### Manual GPU Setup
-If you are unable to use an image which already has NVIDIA CUDA set u p then [this guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#pre-requisites)
+If you are unable to use an image which already has NVIDIA CUDA set up then [this guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#pre-requisites)
 has information on how to install all of the pre-requisites on a wide variety of Operating Systems. 
 You should only need the 'Installation Guide', but sections of the 'User Guide' may be useful for debugging or improving your understanding.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This can be found in the Github Repository, as well as inside the Docker image.
 
 ## Using the Docker images
 
-Our Pod (Process Of Data) docker image is available via Github Container Registry: `ghcr.io/bitfount/pod:stable`
+Our Pod (Processor Of Data) docker image is available via Github Container Registry: `ghcr.io/bitfount/pod:stable`
 
 If you have any problems with any of the steps in this README then feel free to reach out to us.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: "3"
+services:
+  pod:
+    image: ghcr.io/bitfount/pod:stable
+    volumes:
+      # You would need to define a config file on your host machine at `~/.bitfount_dev/docker/config.yaml`.
+      - "~/.bitfount_dev/docker:/mount/config"
+
+  gpu-pod:
+      image: ghcr.io/bitfount/pod:stable
+      volumes:
+        # You would need to define a config file on your host machine at `~/.bitfount_dev/docker/config.yaml`.
+        - "~/.bitfount_dev/docker:/mount/config"
+      # Below is an example giving access to an NVIDIA GPU. 
+      # As there are many different setups we recommend that you review the documentation to ensure you give access
+      # to the desired hardware https://docs.docker.com/compose/gpu-support/
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [gpu]
+
+  gpu-checker:
+      image: ghcr.io/bitfount/pod:stable
+      entrypoint: nvidia-smi
+      # Below is an example giving access to an NVIDIA GPU. 
+      # As there are many different setups we recommend that you review the documentation to ensure you give access
+      # to the desired hardware https://docs.docker.com/compose/gpu-support/
+      deploy:
+        resources:
+          reservations:
+            devices:
+              - driver: nvidia
+                count: 1
+                capabilities: [gpu]


### PR DESCRIPTION
This documentation was difficult to follow and made it hard to reproduce user's issues. This PR promotes the use of docker compose as the default (as it's now packaged as part of docker) - which also results in us being able to more easily reproduce user's issues by sharing of compose files.